### PR TITLE
Adapt layout to fit components on mobile

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -70,7 +70,15 @@ code {
     min-width: 100px;
     word-break: break-all;
     white-space: normal;
+    position: relative;
+    display: flex;
+    flex-direction: row;
 }
+
+.word-card p {
+  flex-grow: 1;
+}
+
 
 .rcard {
     /* font-size: 1.5em; */
@@ -212,12 +220,20 @@ code {
 }
 
 @media only screen and (max-height: 720px) and (max-width:1200px) {
-    .word-card.blue {
-        display: none;
-    }
-    .word-card.yellow {
-        display: none;
-    }
+
+  .word-card {
+    height: 60px;
+    line-height: 60px;
+  }
+
+  .word-card p {
+    line-height: 60px;
+  }
+
+  .rcard-image {
+    width: 60px;
+  }
+
 }
 
 .no-l-padding {
@@ -300,3 +316,6 @@ ul#nav li {
 .center-div{
   width: 1010px;
 } */
+
+
+

--- a/web/src/userio.js
+++ b/web/src/userio.js
@@ -170,12 +170,8 @@ class RightCard extends React.Component {
 
         return (
             <div className={"container card word-card rcard " + this.props.cls}>
-                <div style={{ height: "100px" }}>
-                    <img style={{ display: "inline-block", width: "100px", marginTop: "-92px" }} className="rcard-image" alt="" src={this.props.image} />
-                    <div style={{ display: "inline-block", width: this.state.width - 120 + "px" }}>
-                        <p className="card-text rtext" style={style}>{this.props.text}</p>
-                    </div>
-                </div>
+                <img className="rcard-image" alt="" src={this.props.image} />
+                <p className="card-text rtext" style={style}>{this.props.text}</p>
             </div>
         )
     }


### PR DESCRIPTION
Thank you for the website! This is a great ways to practice conjugations. Most of my practice is on mobile, so I have a few adaptations that I think will work well. 

move static styles out of userio.js (leave font sizing obvi). 
Update css to handle the layout, using display flex instead of inline block. 
Add rules to resize cards on mobile devices.